### PR TITLE
add support for gx531 layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ This builds upon the work done in [asus-touchpad-numpad-driver](https://github.c
 ## Run
 * `sudo modprobe i2c-dev` and `sudo modprobe uinput`
     * You can have them be loaded automatically at boot. Consult [ArchWiki](https://wiki.archlinux.org/title/Kernel_module#Automatic_module_loading_with_systemd) for details
-* Create the config file at `/etc/xdg/asus_numpad.toml` and add `layout = "LAYOUT"`, where `LAYOUT` is one of `UX433FA`, `M433IA`, `UX581`, or `GX701`. See [Configuration](#Configuration) for more options.
+* Create the config file at `/etc/xdg/asus_numpad.toml` and add `layout = "LAYOUT"`, where `LAYOUT` is one of `UX433FA`, `M433IA`, `UX581`, `GX701` or `GX531`. See [Configuration](#Configuration) for more options.
+
 * `sudo asus-numpad`
 
 ## Running without `sudo`
@@ -68,7 +69,7 @@ The config file is stored in TOML format at `/etc/xdg/asus_numpad.toml`. It supp
 
 name | type | default | desc
 --- | --- | --- | ---
-`layout` | `string` | **Required** | One of `UX433FA`, `M433IA`, `UX581`, or `GX701`.
+`layout` | `string` | **Required** | One of `UX433FA`, `M433IA`, `UX581`, `GX701` or `GX531`.
 `calc_start_command` | <ol type="a"><li> Array of [`EV_KEY`](https://docs.rs/evdev-rs/latest/evdev_rs/enums/enum.EV_KEY.html), or </li> <li> `{cmd = "some_binary", args = ["arg1", "arg2]}` </li> | `["KEY_CALC"]` | Defines what is to be done when calc key is dragged. <br> If variant `a` is used, the specified keys will be pressed. Variant `b` allows running an arbitrary command. 
 `calc_stop_command` | Same as `calc_start_command` | _Not specified_ | Defines what is to be done when calc key is dragged the second time. Useful for closing/killing a launched process. If not specified, the `calc_start_command` will be triggered. 
 `disable_numlock_on_start` | `bool` | `true` | Specifies whether we should deactivate the numlock when starting up.

--- a/src/numpad_layout.rs
+++ b/src/numpad_layout.rs
@@ -89,6 +89,7 @@ pub(crate) enum SupportedLayout {
     M433IA,
     UX581,
     GX701,
+    GX531,
 }
 
 impl NumpadLayout {
@@ -263,6 +264,30 @@ impl NumpadLayout {
         )
     }
 
+    pub fn gx531(bbox: BBox) -> Self {
+        use EV_KEY::*;
+        Self::create(
+            vec![
+                vec![KEY_BACKSLASH, KEY_KPSLASH, KEY_KPASTERISK, KEY_KPMINUS],
+                vec![KEY_KP7, KEY_KP8, KEY_KP9, KEY_KPPLUS],
+                vec![KEY_KP4, KEY_KP5, KEY_KP6, KEY_KPPLUS],
+                vec![KEY_KP1, KEY_KP2, KEY_KP3, KEY_KPENTER],
+                vec![KEY_KP0, KEY_KP0, KEY_KPDOT, KEY_KPENTER],
+            ],
+            bbox.apply_margins(Margins {
+                top: 0.005,
+                bottom: 0.005,
+                left: 0.005,
+                right: 0.005,
+            }),
+            // these bboxes aren't present on this model.
+            // set to values outside the actual touchpad bbox.
+            // this way, they will never be activated.
+            bbox.disjoint_dummy(),
+            bbox.disjoint_dummy(),
+        )
+    }
+
     pub(crate) fn from_supported_layout(layout: &SupportedLayout, bbox: BBox) -> Result<Self> {
         use SupportedLayout::*;
         let layout = match layout {
@@ -270,6 +295,7 @@ impl NumpadLayout {
             M433IA => Self::m433ia(bbox),
             UX581 => Self::ux581(bbox),
             GX701 => Self::gx701(bbox),
+            GX531 => Self::gx531(bbox),
         };
         Ok(layout)
     }


### PR DESCRIPTION
This PR adds support for the numpads of the GX531 family of laptops.